### PR TITLE
Use absolute path when reading `start.sh`

### DIFF
--- a/minecraft-ftb/data/docker-entrypoint.sh
+++ b/minecraft-ftb/data/docker-entrypoint.sh
@@ -135,7 +135,7 @@ patch_start_script() {
         fi
 
         output+="${line}\n"
-    done < start.sh
+    done < /var/lib/minecraft/start.sh
 
     if [ ! "${success}" ]; then
         echoerr "Failed to patch 'start.sh' script."


### PR DESCRIPTION
Related to #8