### PR TITLE
Add `GID`/`UID` environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ possible.
 - Supports unattended installation (see `ACCEPT_MOJANG_EULA`)
 - Supports configuration of user-defined JVM arguments as part of the container configuration (see `USER_JVM_ARGS`)
 - Drops `root` privileges after setting up the container and runs the server as an unprivileged user
+  - Allows to customize the internal user (see `GID`/`UID`)
 - Multi architecture support (`x86-64`/`amd64`, `aarch64`/`arm64`)
 
 ![Screenshot](./screenshot.png)
@@ -129,6 +130,18 @@ Set `1` to force a reinstallation of the modpack when the container is started.
 > container.
 
 Default: `0`
+
+### `GID`
+
+The `GID` of the internal `minecraft` group.
+
+Default: `99`
+
+### `UID`
+
+The `UID` of the internal `minecraft` user.
+
+Default: `99`
 
 ## License
 

--- a/minecraft-ftb/data/Dockerfile
+++ b/minecraft-ftb/data/Dockerfile
@@ -2,6 +2,8 @@ FROM debian:bookworm-slim
 
 # Environment
 
+ENV UID=99
+ENV GID=99
 ENV FTB_MODPACK_ID=0
 ENV FTB_MODPACK_VERSION_ID=0
 ENV ACCEPT_MOJANG_EULA=0
@@ -13,29 +15,15 @@ ENV FORCE_REINSTALL=0
 
 # hadolint ignore=DL3008
 RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
         curl \
         jq \
-	; \
+    ; \
     rm -rf /var/lib/apt/lists/*
 
-# Set up container user
-
-# hadolint ignore=DL3008
-RUN set -eux; \
-	groupadd --gid 99 --system minecraft; \
-	useradd \
-		--gid minecraft \
-		--home-dir /var/lib/minecraft \
-		--no-create-home \
-		--system \
-		--uid 99 \
-		minecraft \
-	; \
-	mkdir /var/lib/minecraft; \
-	chown minecraft:minecraft /var/lib/minecraft
+RUN mkdir /var/lib/minecraft
 
 # Entrypoint config
 


### PR DESCRIPTION
Add `GID`/`UID` environment variables to allow customization of the internal user.

Related to #8 
Closes #14