### PR TITLE
Pin reviewdog actions to commit SHAs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Lint
-        uses: reviewdog/action-hadolint@v1
+        uses: reviewdog/action-hadolint@921946a7ebaaf08ac72607bad67209f4e52b5407 # v1.50.5
         with:
           reporter: github-pr-check
           filter_mode: nofilter
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Lint
-        uses: reviewdog/action-shellcheck@v1
+        uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
         with:
           reporter: github-pr-check
           filter_mode: nofilter
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Lint
-        uses: reviewdog/action-markdownlint@v0
+        uses: reviewdog/action-markdownlint@3667398db9118d7e78f7a63d10e26ce454ba5f58 # v0.26.2
         with:
           reporter: github-pr-check
           filter_mode: nofilter
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Lint
-        uses: reviewdog/action-yamllint@v1
+        uses: reviewdog/action-yamllint@f01d8a48fd8d89f89895499fca2cff09f9e9e8c0 # v1.21.0
         with:
           reporter: github-pr-check
           filter_mode: nofilter
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Lint
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@0d952c597ef8459f634d7145b0b044a9699e5e43 # v1.71.0
         with:
           reporter: github-pr-check
           filter_mode: nofilter


### PR DESCRIPTION
## Summary

- Pin all reviewdog actions to commit SHAs for improved supply-chain security
- Update to latest patch versions